### PR TITLE
Drop use of discouraged 'sort' pragma

### DIFF
--- a/lib/Devel/INC/Sorted.pm
+++ b/lib/Devel/INC/Sorted.pm
@@ -6,8 +6,6 @@ use base 'Tie::Array';
 use strict;
 use warnings;
 
-use sort 'stable';
-
 use Exporter;
 use Scalar::Util qw(blessed reftype);
 use Tie::RefHash;


### PR DESCRIPTION
As per https://perldoc.perl.org/sort:

> The sort pragma is now a no-op, and its use is discouraged.